### PR TITLE
Get local setup back to a working state following the README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,4 @@ MAPPED_DB_PORT=5432
 
 ## App env vars
 PORT=4000
-DATABASE_URL=postgres://public:data_management_tool@database:5432/main?schema=public
+DATABASE_URL=postgres://data_management_tool:secret@database:5432/data_management_tool?schema=public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
   docs:
     image: imbios/bun-node
     command: bun run docs:dev
-    # command: bun --version
     ports:
       - ${MAPPED_DOCS_PORT:-5173}:5173
     volumes:


### PR DESCRIPTION
## Fixes

- I noticed after following the README that the local setup just wasn't working. This should fix that, after simply copying the `.env.example` to `.env`